### PR TITLE
Fix CI role install from repo

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,3 +1,5 @@
 skip_list:
   - 'name[casing]'
   - 'key-order[task]'
+exclude_paths:
+  - tests/roles/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   lint-and-test:
     runs-on: ubuntu-latest
+    env:
+      ANSIBLE_ROLES_PATH: tests/roles
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,18 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install ansible ansible-lint
+      - name: Install role from repository
+        run: |
+          cat <<EOF > requirements.yml
+          - src: https://github.com/${{ github.repository }}.git
+            scm: git
+            version: ${{ github.sha }}
+            name: oatakan.rhel_template_build
+          EOF
+          ansible-galaxy role install -r requirements.yml
+      - name: Install required collections
+        run: ansible-galaxy collection install community.general
       - name: Run ansible-lint
-        run: ansible-lint
+        run: ansible-lint --offline
       - name: Syntax check
         run: ansible-playbook -i tests/inventory tests/test.yml --syntax-check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,7 @@ jobs:
       - name: Install role from repository
         run: |
           cat <<EOF > requirements.yml
-          - src: https://github.com/${{ github.repository }}.git
-            scm: git
+          - src: git+https://github.com/${{ github.repository }}.git
             version: ${{ github.sha }}
             name: oatakan.rhel_template_build
           EOF

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,13 @@ jobs:
           pip install ansible ansible-lint
       - name: Install role from repository
         run: |
-          ansible-galaxy role install git+https://github.com/${{ github.repository }}.git,${{ github.sha }} -p tests/roles
+          cat <<'EOF' > requirements.yml
+          - src: https://github.com/${{ github.repository }}.git
+            scm: git
+            version: ${{ github.event.pull_request.head.sha || github.sha }}
+            name: oatakan.rhel_template_build
+          EOF
+          ansible-galaxy role install -r requirements.yml -p tests/roles
       - name: Install required collections
         run: ansible-galaxy collection install community.general
       - name: Run ansible-lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,7 @@ jobs:
           pip install ansible ansible-lint
       - name: Install role from repository
         run: |
-          cat <<EOF > requirements.yml
-          - src: git+https://github.com/${{ github.repository }}.git
-            version: ${{ github.sha }}
-            name: oatakan.rhel_template_build
-          EOF
-          ansible-galaxy role install -r requirements.yml
+          ansible-galaxy role install git+https://github.com/${{ github.repository }}.git,${{ github.sha }} -p tests/roles
       - name: Install required collections
         run: ansible-galaxy collection install community.general
       - name: Run ansible-lint


### PR DESCRIPTION
## Summary
- install role via git in CI instead of galaxy
- install required collections
- run ansible-lint in offline mode

## Testing
- `ansible-lint --offline`
- `ansible-playbook -i tests/inventory tests/test.yml --syntax-check`


------
https://chatgpt.com/codex/tasks/task_e_684a788fe1a4832d947c98e128d69236