### PR TITLE
Add Molecule integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           EOF
           ansible-galaxy role install -r requirements.yml -p tests/roles
       - name: Install required collections
-        run: ansible-galaxy collection install community.general
+        run: ansible-galaxy collection install community.general community.docker
       - name: Run ansible-lint
         run: ansible-lint --offline
       - name: Syntax check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   lint-and-test:
     runs-on: ubuntu-latest
     env:
-      ANSIBLE_ROLES_PATH: tests/roles
+      ANSIBLE_ROLES_PATH: ${{ github.workspace }}/tests/roles
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,7 @@ jobs:
         run: ansible-lint --offline
       - name: Syntax check
         run: ansible-playbook -i tests/inventory tests/test.yml --syntax-check
+      - name: Install Molecule
+        run: pip install 'molecule[docker]'
+      - name: Test with Molecule
+        run: molecule test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
             name: oatakan.rhel_template_build
           EOF
           ansible-galaxy role install -r requirements.yml -p tests/roles
+          rm requirements.yml
       - name: Install required collections
         run: ansible-galaxy collection install community.general community.docker
       - name: Run ansible-lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,6 @@ jobs:
       - name: Syntax check
         run: ansible-playbook -i tests/inventory tests/test.yml --syntax-check
       - name: Install Molecule
-        run: pip install 'molecule[docker]'
+        run: pip install molecule molecule-plugins[docker]
       - name: Test with Molecule
         run: molecule test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,5 +37,7 @@ jobs:
         run: ansible-playbook -i tests/inventory tests/test.yml --syntax-check
       - name: Install Molecule
         run: pip install molecule molecule-plugins[docker]
+      - name: Start Docker
+        run: sudo systemctl start docker
       - name: Test with Molecule
         run: molecule test

--- a/README.md
+++ b/README.md
@@ -48,10 +48,12 @@ ansible-playbook -i tests/inventory tests/test.yml --syntax-check
 ```
 
 To execute integration tests in a containerized environment, install Molecule
-and its Docker plugin before running the tests:
+and its Docker plugin, then install the required Ansible collection before
+running the tests:
 
 ```bash
 pip install molecule molecule-plugins[docker]
+ansible-galaxy collection install community.docker
 molecule test
 ```
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ ANSIBLE_ROLES_PATH=$(pwd)/tests/roles molecule test
 Docker must be installed and the Docker daemon should be running before
 executing the Molecule scenario.
 
-The scenario uses an `ansible.cfg` that sets `remote_tmp` to `/tmp` so
+The scenario uses an `ansible.cfg` that sets `remote_tmp` to `/tmp/.ansible` so
 temporary files can be created inside the container. Molecule sets the
 `ANSIBLE_CONFIG` environment variable so Ansible loads this configuration.
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ ansible-galaxy collection install community.docker
 ANSIBLE_ROLES_PATH=$(pwd)/tests/roles molecule test
 ```
 
+Docker must be installed and the Docker daemon should be running before
+executing the Molecule scenario.
+
 The scenario uses an `ansible.cfg` that sets `remote_tmp` to `/tmp/.ansible` so
 temporary files can be created inside the container. Molecule sets the
 `ANSIBLE_CONFIG` environment variable so Ansible loads this configuration.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ ansible-lint
 ansible-playbook -i tests/inventory tests/test.yml --syntax-check
 ```
 
+To execute integration tests in a containerized environment, install Molecule
+with the Docker driver and run:
+
+```bash
+pip install 'molecule[docker]'
+molecule test
+```
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ ansible-galaxy collection install community.docker
 molecule test
 ```
 
+The provided Molecule scenario builds a systemd-enabled Rocky Linux 9 image
+with Python installed so the role can run inside a Docker container.
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -40,11 +40,12 @@ If Parallels guest tools are required, ensure the [`oatakan.linux_parallels_tool
 ## Testing the role
 
 An automated GitHub Actions workflow runs `ansible-lint` and performs a playbook
-syntax check whenever changes are pushed. You can run the same checks locally:
+syntax check whenever changes are pushed. You can run the same checks locally by
+setting `ANSIBLE_ROLES_PATH` to point at the test roles directory:
 
 ```bash
-ansible-lint
-ansible-playbook -i tests/inventory tests/test.yml --syntax-check
+ANSIBLE_ROLES_PATH=$(pwd)/tests/roles ansible-lint --offline
+ANSIBLE_ROLES_PATH=$(pwd)/tests/roles ansible-playbook -i tests/inventory tests/test.yml --syntax-check
 ```
 
 To execute integration tests in a containerized environment, install Molecule
@@ -54,7 +55,7 @@ running the tests:
 ```bash
 pip install molecule molecule-plugins[docker]
 ansible-galaxy collection install community.docker
-molecule test
+ANSIBLE_ROLES_PATH=$(pwd)/tests/roles molecule test
 ```
 
 The scenario uses an `ansible.cfg` that sets `remote_tmp` to `/tmp/.ansible` so

--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ The scenario uses an `ansible.cfg` that sets `remote_tmp` to `/tmp/.ansible` so
 temporary files can be created inside the container. Molecule sets the
 `ANSIBLE_CONFIG` environment variable so Ansible loads this configuration.
 
+The Docker image used for testing creates this directory during build to
+avoid permission issues when Ansible gathers facts.
+
 The Molecule scenario builds a container from `quay.io/rockylinux/rockylinux:9`
 and installs `systemd` and Python so the role can run in a Docker container.
 

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ ansible-galaxy collection install community.docker
 molecule test
 ```
 
-The provided Molecule scenario builds a systemd-enabled Rocky Linux 9 image
-with Python installed so the role can run inside a Docker container.
+The Molecule scenario builds a container from `quay.io/rockylinux/rockylinux:9`
+and installs `systemd` and Python so the role can run in a Docker container.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ ANSIBLE_ROLES_PATH=$(pwd)/tests/roles molecule test
 Docker must be installed and the Docker daemon should be running before
 executing the Molecule scenario.
 
-The scenario uses an `ansible.cfg` that sets `remote_tmp` to `/tmp/.ansible` so
+The scenario uses an `ansible.cfg` that sets `remote_tmp` to `/tmp` so
 temporary files can be created inside the container. Molecule sets the
 `ANSIBLE_CONFIG` environment variable so Ansible loads this configuration.
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ molecule test
 ```
 
 The scenario uses an `ansible.cfg` that sets `remote_tmp` to `/tmp/.ansible` so
-temporary files can be created inside the container.
+temporary files can be created inside the container. Molecule sets the
+`ANSIBLE_CONFIG` environment variable so Ansible loads this configuration.
 
 The Molecule scenario builds a container from `quay.io/rockylinux/rockylinux:9`
 and installs `systemd` and Python so the role can run in a Docker container.

--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ ansible-playbook -i tests/inventory tests/test.yml --syntax-check
 ```
 
 To execute integration tests in a containerized environment, install Molecule
-with the Docker driver and run:
+and its Docker plugin before running the tests:
 
 ```bash
-pip install 'molecule[docker]'
+pip install molecule molecule-plugins[docker]
 molecule test
 ```
 

--- a/README.md
+++ b/README.md
@@ -61,12 +61,9 @@ ANSIBLE_ROLES_PATH=$(pwd)/tests/roles molecule test
 Docker must be installed and the Docker daemon should be running before
 executing the Molecule scenario.
 
-The scenario uses an `ansible.cfg` that sets `remote_tmp` to `/tmp/.ansible` so
+The scenario uses an `ansible.cfg` that sets `remote_tmp` to `/tmp` so
 temporary files can be created inside the container. Molecule sets the
 `ANSIBLE_CONFIG` environment variable so Ansible loads this configuration.
-
-The Docker image used for testing creates this directory during build to
-avoid permission issues when Ansible gathers facts.
 
 The Molecule scenario builds a container from `quay.io/rockylinux/rockylinux:9`
 and installs `systemd` and Python so the role can run in a Docker container.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ ansible-galaxy collection install community.docker
 molecule test
 ```
 
+The scenario uses an `ansible.cfg` that sets `remote_tmp` to `/tmp/.ansible` so
+temporary files can be created inside the container.
+
 The Molecule scenario builds a container from `quay.io/rockylinux/rockylinux:9`
 and installs `systemd` and Python so the role can run in a Docker container.
 

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -1,0 +1,3 @@
+FROM quay.io/rockylinux/rockylinux:9-ubi-init
+RUN dnf -y install python3 sudo && dnf clean all
+CMD ["/usr/lib/systemd/systemd"]

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -1,4 +1,3 @@
 FROM quay.io/rockylinux/rockylinux:9
-RUN dnf -y install systemd python3 sudo && dnf clean all \
-    && mkdir -p /tmp/.ansible && chmod 0755 /tmp/.ansible
+RUN dnf -y install systemd python3 sudo && dnf clean all
 CMD ["/usr/sbin/init"]

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -1,3 +1,3 @@
-FROM quay.io/rockylinux/rockylinux:9-ubi-init
-RUN dnf -y install python3 sudo && dnf clean all
-CMD ["/usr/lib/systemd/systemd"]
+FROM quay.io/rockylinux/rockylinux:9
+RUN dnf -y install systemd python3 sudo && dnf clean all
+CMD ["/usr/sbin/init"]

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -1,3 +1,4 @@
 FROM quay.io/rockylinux/rockylinux:9
-RUN dnf -y install systemd python3 sudo && dnf clean all
+RUN dnf -y install systemd python3 sudo && dnf clean all \
+    && mkdir -p /tmp/.ansible && chmod 0755 /tmp/.ansible
 CMD ["/usr/sbin/init"]

--- a/molecule/default/ansible.cfg
+++ b/molecule/default/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+remote_tmp = /tmp/.ansible

--- a/molecule/default/ansible.cfg
+++ b/molecule/default/ansible.cfg
@@ -2,4 +2,4 @@
 # Use a standard temporary directory inside the container. Setting this
 # path avoids failures when Ansible tries to create temporary directories
 # during tasks such as fact gathering.
-remote_tmp = /tmp/.ansible
+remote_tmp = /tmp

--- a/molecule/default/ansible.cfg
+++ b/molecule/default/ansible.cfg
@@ -1,2 +1,5 @@
 [defaults]
-remote_tmp = /tmp/.ansible
+# Use a standard temporary directory inside the container. Setting this
+# path avoids failures when Ansible tries to create temporary directories
+# during tasks such as fact gathering.
+remote_tmp = /tmp

--- a/molecule/default/ansible.cfg
+++ b/molecule/default/ansible.cfg
@@ -2,4 +2,4 @@
 # Use a standard temporary directory inside the container. Setting this
 # path avoids failures when Ansible tries to create temporary directories
 # during tasks such as fact gathering.
-remote_tmp = /tmp
+remote_tmp = /tmp/.ansible

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,0 +1,10 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  vars:
+    target_vagrant: false
+    target_ovirt: false
+    local_account_username: root
+  roles:
+    - role: oatakan.rhel_template_build

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,7 +1,6 @@
 ---
 - name: Converge
   hosts: all
-  become: true
   vars:
     target_vagrant: false
     target_ovirt: false

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,6 +1,8 @@
 ---
 dependency:
   name: galaxy
+  options:
+    role-file: requirements.yml
 
 driver:
   name: docker

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -17,6 +17,8 @@ platforms:
 
 provisioner:
   name: ansible
+  env:
+    ANSIBLE_CONFIG: ${MOLECULE_SCENARIO_DIRECTORY}/ansible.cfg
 
 verifier:
   name: ansible

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -7,9 +7,9 @@ driver:
 
 platforms:
   - name: instance
-    image: quay.io/rockylinux/rockylinux:9
+    image: quay.io/rockylinux/rockylinux:9-ubi-init
     privileged: true
-    command: /usr/sbin/init
+    command: /usr/lib/systemd/systemd
     pre_build_image: true
 
 provisioner:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -9,8 +9,11 @@ platforms:
   - name: instance
     image: quay.io/rockylinux/rockylinux:9-ubi-init
     privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/lib/systemd/systemd
-    pre_build_image: true
+    pre_build_image: false
+    dockerfile: Dockerfile.j2
 
 provisioner:
   name: ansible

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -7,11 +7,11 @@ driver:
 
 platforms:
   - name: instance
-    image: quay.io/rockylinux/rockylinux:9-ubi-init
+    image: quay.io/rockylinux/rockylinux:9
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /usr/lib/systemd/systemd
+    command: /usr/sbin/init
     pre_build_image: false
     dockerfile: Dockerfile.j2
 

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,19 @@
+---
+dependency:
+  name: galaxy
+
+driver:
+  name: docker
+
+platforms:
+  - name: instance
+    image: quay.io/rockylinux/rockylinux:9
+    privileged: true
+    command: /usr/sbin/init
+    pre_build_image: true
+
+provisioner:
+  name: ansible
+
+verifier:
+  name: ansible

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,0 +1,2 @@
+collections:
+  - name: community.docker


### PR DESCRIPTION
## Summary
- add Molecule scenario with Docker driver using Rocky Linux 9
- create converge playbook that skips VM-specific tasks
- run Molecule in CI after lint and syntax checks
- document how to run Molecule tests locally

## Testing
- `ANSIBLE_ROLES_PATH=tests/roles ansible-lint --offline`
- `ANSIBLE_ROLES_PATH=tests/roles ansible-playbook -i tests/inventory tests/test.yml --syntax-check`
- `ANSIBLE_ROLES_PATH=tests/roles molecule test` *(fails: Unable to contact the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_684af343a8b8832dbe5bf6f0a4467c93