### PR TITLE
fix auto release create tag

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -254,6 +254,10 @@ jobs:
       # Don't commit changes to master - just create the tag and release
       - name: Create and push tag (using AI version)
         run: |
+          # Configure git user for tag creation
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          
           NEW_TAG="${{ steps.version.outputs.NEW_TAG }}"
           NEW_VERSION="${{ steps.version.outputs.NEW_VERSION }}"
           


### PR DESCRIPTION

<!-- ai-metadata
change_type: chore
risk_level: low
auto_generated: true
-->

## AI-Enhanced Description

This pull request adds configuration for the Git user in the auto-release workflow to ensure that tags can be created and pushed correctly by the GitHub Actions bot.

### Changes Made


### Testing Checklist
- [ ] Run the auto-release workflow to verify that tags are created and pushed successfully.
- [ ] Check the GitHub Actions logs for any errors related to Git configuration.

### Review Checklist
- [ ] Tests pass locally
- [ ] Documentation updated
- [ ] Changelog entry added (if needed)
- [ ] Breaking changes documented (if any)
- [ ] Security implications reviewed
