### PR TITLE
use gh release command for release action

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -295,24 +295,19 @@ jobs:
           echo "✅ Tag pushed to remote"
 
       - name: Create GitHub Release
-        uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ steps.version.outputs.NEW_TAG }}
-          release_name: Release ${{ steps.version.outputs.NEW_TAG }}
-          body: |
+          RELEASE_NOTES: |
             ## Changes in ${{ steps.version.outputs.NEW_TAG }}
-
+      
             ${{ needs.analyze-changes.outputs.changelog_entry }}
-
+      
             **Release Type:** ${{ needs.analyze-changes.outputs.version_bump }}
             **Analysis:** ${{ needs.analyze-changes.outputs.analysis_reasoning }}
-
+      
             ---
             *This release was automatically generated based on AI analysis of the changes.*
-          draft: false
-          prerelease: false
+        run: |
+          echo "$RELEASE_NOTES" | gh release create ${{ steps.version.outputs.NEW_TAG }} --title "Release ${{ steps.version.outputs.NEW_TAG }}" --notes-file -
 
   deploy-galaxy:
     needs: [check-release-needed, analyze-changes, create-release]


### PR DESCRIPTION

<!-- ai-metadata
change_type: enhancement
risk_level: medium
auto_generated: true
-->

## AI-Enhanced Description

This pull request modifies the GitHub Actions workflow to use the 'gh release' command instead of the 'actions/create-release' action for creating releases, streamlining the release process.

### Changes Made


### Testing Checklist
- [ ] Test the workflow in a staging environment to ensure releases are created correctly.
- [ ] Verify that the release notes are formatted correctly and include all necessary information.
- [ ] Check for any errors in the GitHub Actions logs during the release process.

### Review Checklist
- [ ] Tests pass locally
- [ ] Documentation updated
- [ ] Changelog entry added (if needed)
- [ ] Breaking changes documented (if any)
- [ ] Security implications reviewed
